### PR TITLE
fix(readme): correct typo Yif to If

### DIFF
--- a/Projects/project_becoming_her/README.md
+++ b/Projects/project_becoming_her/README.md
@@ -101,7 +101,7 @@ Contributions are welcome! If you'd like to contribute to this project, please f
 
 ## Get in Touch
 
-YIf you have any questions or suggestions, feel free to reach out:
+If you have any questions or suggestions, feel free to reach out:
  - Linkedin- [Morufat-Lamidi](https://linkedin.com/in/morufat-lamidi)
  - Tiktok- [Ehmkay](https://www.tiktok.com/@_ehmkay?)
  - Frontend Mentor - [@Ehmkayel](https://www.frontendmentor.io/profile/Ehmkayel)


### PR DESCRIPTION
fix(readme): correct typo from "YIf" to "If" in "Get in Touch" section

The README file had a minor typo where "YIf" was mistakenly written instead of "If" 
in the context of explaining how to get in touch. This commit corrects it to ensure 
better clarity and maintain a professional tone in the documentation.
