### PR TITLE
feat(js-recap): add study recap page with dynamic year footer and personal intro in console

### DIFF
--- a/Study/Javascript/index.html
+++ b/Study/Javascript/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Javascript Recap</title>
+    <script src="index.js" type="module"></script>
+  </head>
+  <body>
+    <main>
+      <section>
+        <h1>JavaScript Recap Study Notes</h1>
+        <p>This page is dedicated to my JavaScript learning and experiments.</p>
+        <p>To view console output from my scripts:</p>
+        <ul>
+          <li>
+            <b>Windows:</b> Right-click → Inspect → Console tab OR press
+            <code>Ctrl + Shift + J</code>
+          </li>
+          <li>
+            <b>macOS:</b> Right-click → Inspect → Console tab OR press
+            <code>Cmd + Option + J</code>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>What I'm learning</h2>
+        <ul>
+          <li>Modern JavaScript (ES6+)</li>
+          <li>DOM Manipulation</li>
+          <li>Event Handling</li>
+          <li>Functions, Loops, and Conditional Statements</li>
+          <li>Modules & Imports</li>
+          <li>Async JavaScript (Promises, async/await)</li>
+        </ul>
+      </section>
+    </main>
+    <footer>
+      <p>
+        &copy; <span id="year"></span> Morufat Lamidi | JavaScript Study Series
+      </p>
+    </footer>
+  </body>
+</html>

--- a/Study/Javascript/index.js
+++ b/Study/Javascript/index.js
@@ -1,0 +1,10 @@
+const yearSpan = document.getElementById("year");
+const currentYear = new Date().getFullYear();
+yearSpan.textContent = currentYear;
+
+const firstName = "Ramadan";
+const age = 18;
+const techSchool = "Dev Career";
+const details = `I am ${firstName}, a Frontend Developer with a Frontend Engineering Certification from ${techSchool} and I am ${age} years old`;
+
+console.log(`Ramadan's little details: ${details}`);


### PR DESCRIPTION
feat(js-recap): add study recap page with dynamic year footer and personal intro in console

- Created a detailed HTML structure for my JavaScript study recap
- Linked `index.js` as a module 
- Logged personal study intro using template literals in the console
- Dynamically updated the footer year using JavaScript and DOM manipulation
- Included developer friendly instructions for accessing browser console on Windows and macOS
